### PR TITLE
chore: adjust helm versioning trg A1ODT-920

### DIFF
--- a/docs/trg/trg-5/trg-5-3.md
+++ b/docs/trg/trg-5/trg-5-3.md
@@ -9,14 +9,17 @@ title: TRG 5.03 - Version strategy
 
 ## Description
 
-Versioning is a complex topic in Helm charts.
-For more details, see the [official documentation](https://helm.sh/docs/topics/charts/#charts-and-versioning)
-Version numbers can be separated to two categories:
+Correct versioning is crucial when testing and deploying the application.
+It helps identifying issues with the chart or the application image.
+Upgrading or rolling back of the deployment would lead to problems without proper versioning.
 
-- Helm chart version
+For more details, see the [official documentation](https://helm.sh/docs/topics/charts/#charts-and-versioning)
+There are two different version properties for a Helm chart:
+
+- Chart version
 - App version
 
-### Helm chart version
+### Chart version
 
 It is located in the _Chart.yaml_ under the _version_ property.
 It follows semantic versioning.
@@ -25,13 +28,7 @@ The version should be bumped every time the _Chart.yaml_ file or any file in the
 ### App version
 
 The default app version value is located in the _Chart.yaml_ file under the _appVersion_ property.
-The format does not have to follow semantic versioning but it is recommended.
-The _appVersion_ should be used in the templates as the default image tag for the deployment/pod.
-The image tag should be overridable through values files.
+The format does should follow semantic versioning as well, because the appVersion and the image tag of your
+docker images should be aligned. This means, the _appVersion_ should be used in the templates as the default image tag
+for the deployment/pod.
 Every time the _appVersion_ property is upgraded the chart _version_ number should be bumped as well.
-
-## Why
-
-Correct versioning is crucial when testing and deploying the application.
-It helps identifying issues with the chart or the application image.
-Upgrading or rolling back of the deployment would lead to problems without proper versioning.

--- a/docs/trg/trg-5/trg-5-3.md
+++ b/docs/trg/trg-5/trg-5-3.md
@@ -28,7 +28,7 @@ The version should be bumped every time the _Chart.yaml_ file or any file in the
 ### App version
 
 The default app version value is located in the _Chart.yaml_ file under the _appVersion_ property.
-The format does should follow semantic versioning as well, because the appVersion and the image tag of your
+The format should follow semantic versioning as well, because the appVersion and the image tag of your
 docker images should be aligned. This means, the _appVersion_ should be used in the templates as the default image tag
 for the deployment/pod.
 Every time the _appVersion_ property is upgraded the chart _version_ number should be bumped as well.


### PR DESCRIPTION
Proposal on TRG-5.03 adjustments. 
Changes:
- Put the 'Why' content to the opening description
- Put more emphasis on semantic version also for appVersion, since this version should align with the docker image tags and we require semantic version on the image tags