### PR TITLE
feat: test-deploy checkout version bump

### DIFF
--- a/.github/workflows/test-deploy.yaml
+++ b/.github/workflows/test-deploy.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Test deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x


### PR DESCRIPTION
v2 used NodeJs v12 which is deprecated, v3 uses NodeJs v16