### PR TITLE
fix: adapt new TRG link

### DIFF
--- a/docs/trg/trg-0.md
+++ b/docs/trg/trg-0.md
@@ -17,10 +17,10 @@ record. The TRGs are indexed by topic for specialist subjects.
 
 :::danger TRG Content move over to Tractusx
 Potential new TRGs won't be published here, but in
-Eclipse-Tractusx you can find the current TRG: [https://eclipse-tractusx.github.io/docs/category/release-guidelines](https://eclipse-tractusx.github.io/docs/category/release-guidelines)
+Eclipse-Tractusx you can find the current TRG: [https://eclipse-tractusx.github.io/docs/release](https://eclipse-tractusx.github.io/docs/release)
 
 Please update your bookmarks and always check
-the [Eclipse-Tractusx Release Guidlines website](https://eclipse-tractusx.github.io/docs/category/release-guidelines)
+the [Eclipse-Tractusx Release Guidlines website](https://eclipse-tractusx.github.io/docs/release)
 instead of this one.
 
 :::


### PR DESCRIPTION
Found out that the former link was not found since some changes to the structure from the TRG's and modified this to current link.

old:        
https://eclipse-tractusx.github.io/docs/category/release-guidelines
current: 
https://eclipse-tractusx.github.io/docs/release

- tested it locally only by changing the link
>  'npm install' and 'npm start'