### PR TITLE
new GitHub issue template links

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -15,8 +15,8 @@ out to us on the
 
 If you need access to repositories inside the catenax-ng organization or you want to use ArgoCD for deploying an
 application on one of the demonstrator environments, you need to request an invitation to the catenax-ng GitHub
-organization via
-[this Jira template](https://jira.catena-x.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=10401&components=10401&priority=3&summary=GitHub%3A%20Invite%20member&description=%0AGitHub%20user%3A%20_your_user_%0AVouching%20person%3A%20_your_PO_&labels=XS).
+organization via this
+[GitHub issue template](https://github.com/catenax-ng/product-onboarding/issues/new?assignees=&labels=support&template=support--invite-member-to-github-org.md&title=GitHub%3A+Invite+member).
 
 Once you are part of the organization, you can be invited to teams by maintainers of the different product teams. If
 there is no team inside the organization for your product yet, you can request that too.
@@ -24,8 +24,8 @@ there is no team inside the organization for your product yet, you can request t
 ## Complete onboarding of a new product
 
 If you are responsible for a new product which has to be onboarded (including new team, new repo, ArgoCD and Vault)
-please use
-[this Jira template](https://jira.catena-x.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=10401&components=10401&priority=3&summary=Onboard%20new%20product&description=Product%20name%3A%20%0AGitHub%20users%20to%20invite%3A%20_github_user_account_%20%0AVouching%20person%3A%20_your_PO_&labels=L).
+please use this
+[GitHub issue template](https://github.com/catenax-ng/product-onboarding/issues/new?assignees=&labels=support&template=support--onboard-a-new-product.md&title=New+Product).
 
 ## GitHub team in catenax-ng
 
@@ -33,8 +33,8 @@ GitHub teams are used to grant multiple user access to the same resources. Teams
 projects in ArgoCD and secrets in Vault. Usually each Catena-X product team will have one team in the catenax-ng GitHub
 organization.
 
-You can issue this request via
-[this Jira template](https://jira.catena-x.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=10401&components=10401&priority=3&summary=GitHub%3A%20New%20Team&description=%0AProduct%20team%20name%3A%20_your_product_team_name_%0AGitHub%20users%20to%20invite%3A%20%0A%20%20-%20_github_user_account_&labels=XS).
+You can issue this request via this
+[GitHub issue template](https://github.com/catenax-ng/product-onboarding/issues/new?assignees=&labels=support&template=support--request-access-to-an-existing-environment-namespace.md&title=Environment%3A+request+access).
 
 The initially invited people will be granted maintainer access to the team. Every additional team member will then be
 invited by one of the maintainers.
@@ -48,8 +48,8 @@ eclipse foundation, you can still use catenax-ng for deployment specific configu
 
 There is an option to use the [k8s-helm-example](https://github.com/catenax-ng/k8s-helm-example) repository to use as a **template for the new repository**. It serves as a jumpstart with a basic **helm chart** setup, enabled **github pages** and **github action to release helm charts** to github pages. This option can be requested in the Jira template.
 
-To request a new repository, please use
-[this Jira template](https://jira.catena-x.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=10401&components=10401&priority=3&summary=GitHub%3A%20New%20repository&description=%0Arepository%20name%3A%20product-_your_product_name_%0A%0Ause%20https%3A%2F%2Fgithub.com%2Fcatenax-ng%2Fk8s-helm-example%C2%A0repo%20as%20template%20and%20setup%20github%20pages%20for%20helm%20publishing%3A%20_yes%2Fno_%0A%0A%0AGitHub%20team%20to%20grant%20access%3A%0A%0A_github_team_name_&labels=XS).
+To request a new repository, please use this
+[GitHub issue template](https://github.com/catenax-ng/product-onboarding/issues/new?assignees=&labels=support&template=support--create-a-new-github-repository.md&title=GitHub%3A+New+repository+).
 
 :::info
 
@@ -63,8 +63,8 @@ questions regarding this, feel free to reach out in the CoP channel.
 
 If your leading product repository is already in the [eclipse-tractusx](https://github.com/eclipse-tractusx) GitHub
 organization, but you want to contribute via PR, you could request a fork into our
-[catenax-ng](https://github.com/catenax-ng) organization. You can use
-[this Jira template](https://jira.catena-x.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=10401&components=10401&priority=3&summary=GitHub%3A%20New%20tractus-x%20fork&description=%0Atractus-repository%20name%3A%20_repo_name_%0A%0Acatenax-ng%20repo%20name%3A%20tx-_repo_name_%0A%0AGitHub%20team%20to%20grant%20access%3A_github_team_name_)
+[catenax-ng](https://github.com/catenax-ng) organization. You can use this
+[GitHub issue template](https://github.com/catenax-ng/product-onboarding/issues/new?assignees=&labels=support&template=support--create-a-new-fork.md&title=GitHub%3A+New+Tractus-X+fork)
 to provide us with the necessary information, so we'll create that fork for you.
 
 ## Request access to an existing environment/namespace
@@ -74,7 +74,7 @@ catenax-ng GitHub organization. If not, please request access first, like descri
 in [this section](https://catenax-ng.github.io/docs/resources#user-invitation-to-the-catenax-ng-github-organization).
 
 If you are already a member of the GitHub organization, please
-use [this Jira template](https://jira.catena-x.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=10401&components=10401&priority=3&summary=Environment%3A%20request%20access&description=%0AEnvironment%3A%20_DEV%20%2F%20INT_%0Anamespace%3A%20_name_of_namespace_%0AGitHub%20team%3A%20_team_that_should_have_access_%0AGitHub%20users%3A%20_github_user_that_should_have_access_&labels=S)
+use this [GitHub issue template](https://github.com/catenax-ng/product-onboarding/issues/new?assignees=&labels=support&template=support--request-access-to-an-existing-environment-namespace.md&title=Environment%3A+request+access)
 to request access.
 
 ## Request environment
@@ -87,8 +87,8 @@ Any environment beside DEV, INT and PRE-PROD should have a very specific use cas
 event. In such cases, we provide a dedicated environment, that will only persist for this demonstration and will be
 deleted afterwards.
 
-Please use
-[this Jira template](https://jira.catena-x.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=10401&components=10401&priority=3&summary=NEW%20ENVIRONMENT&description=%0APurpose%3A%20_environment_purpose_%0ARequested%20by%3A%20_person_requesting_the_demonstration_environment_%0AEnd%20date%20of%20demonstration%3A%20_dd.mm.yyyy_%0ATeams%20participating%3A%0A-%20_product_team_name_&lables=XL)
+Please use this
+[GitHub issue template](https://github.com/catenax-ng/product-onboarding/issues/new?assignees=&labels=support&template=support--create-a-new-environment.md&title=New+Environment)
 and fill out the details in the description.
 
 ## Request databases and other Azure services
@@ -103,7 +103,7 @@ We will provide azure services soon but only for critical / central services.
 Currently SonarCloud is NOT mandatory for Release 1. VeraCode is. If you want to use SonarCloud right now, you can
 request scanning of **public** repositories (**private** are not supported!).
 
-Use [this Jira template](https://jira.catena-x.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=10401&components=10401&priority=3&summary=SonarCloud%20onboarding&description=Public%20repository%20...&labels=S)
+Use this [GitHub issue template](https://github.com/catenax-ng/product-onboarding/issues/new?assignees=&labels=security&template=security-support--sonarcloud-onboarding.md&title=SonarCloud+Onboarding)
 for SonarCloud support.
 
 ## Request assistance from Security team
@@ -119,16 +119,16 @@ are:
 - Gitguardian
 - Invicti
 
-Please use
-[this Jira template](https://jira.catena-x.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=10401&components=10401&priority=3&summary=Security%20request&description=Please%20specify%20the%20type%20of%20request.%20Exemplary%20requests%20are%3A%20%0A%20%20-%20Veracode%20%28initial%20setup%2C%20github%20integration%2C%20Jira%20integration%29%20%0A%20%20-%20Trivvy%20%0A%20%20-%20KICS%20%0A%20%20-%20Gitguardian%20%0A%20%20-%20Pentesting%20%0A%20%20-%20Security%20risk%20assessment%20%28RRA%2C%20Threat%20modeling%2C%20Code%20reviews%29%0A&assignee=piotr.stys.external%40zf.com&labels=L).
+Please use this
+[GitHub issue template](https://github.com/catenax-ng/product-onboarding/issues/new?assignees=&labels=security&template=security-support--request.md&title=Security+Request).
 
 ## Template for any requirement
 
 If none of the topics apply or the
 [CoP Channel](https://teams.microsoft.com/l/channel/19%3a9a3c4a05a3514d07b973c13e7b468709%40thread.tacv2/CX%2520-%2520CoP%2520DevSecOps?groupId=17b1a2dc-67fb-4a49-a2ed-dd1344321439&tenantId=1ad22c6d-2f08-4f05-a0ba-e17f6ce88380)
 does not seem to be the right channel,
-a [JIRA](https://jira.catena-x.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=10401&components=10401&priority=3&summary=blank%20template%20for%20any%20requirement&description=%0AGitHub%20user%3A%20_your_user_%0Ablank_template&labels=requirement-dependent)
-'blank template' is available.
+a general [GitHub Issue](https://github.com/catenax-ng/product-onboarding/issues/new?assignees=&labels=help+wanted%2C+support&template=support--general-requirement.md&title=)
+ is available.
 
 ## General consulting requests
 


### PR DESCRIPTION
After moving issue templates to product-onboarding repository we have now issue templates we can use.

- adapted the links in our "Things to Request" ressource in .md 

tested it locally with `npm install` & `npm start` and checked if the URL will open the correct template for request things from the System Team
