### PR TITLE
chore(docs): add news blog entry from last office hour

### DIFF
--- a/blog/2023-06-16-OfficeHours.md
+++ b/blog/2023-06-16-OfficeHours.md
@@ -1,0 +1,40 @@
+---
+slug: Office Hours 2023-06-16
+title: Office Hours 2023-06-16
+authors: DevSecOps
+tags: [ news, officehour ]
+---
+
+## General updates / information
+
+### DevSecOps
+
+- Welcome New System Team Member [Tomasz Barwicki](https://github.com/tomaszbarwicki)
+- New general [Pull-Request Template](https://github.com/eclipse-tractusx/.github/blob/main/.github/pull_request_template.md) is available
+- New Welcome Page for Catena-X GitHub Organisation [`profile/ReadMe.md`](https://github.com/catenax-ng)
+
+### Security
+
+- The committers gh-team (automotive-tractusx-committers) is now Security Managers for the [Tractus-X Organisation-Link](https://github.com/organizations/eclipse-tractusx/settings/security_analysis)
+- We have still budget for Penetration Testing. Feel free to contact our security team [Security Issue Template](https://github.com/eclipse-tractusx/sig-infra/issues/new?assignees=the-tatanka&labels=security&projects=&template=security-support-request.md&title=)
+- Trivy scans also can scan Docker Hub. Please adjust your GitHub action workflows as shown in this [ReadMe.md](https://github.com/aquasecurity/trivy-action#using-trivy-with-github-code-scanning)
+- Please check your Veracode [Confluence Page](https://confluence.catena-x.net/display/BDPQ/%5BBT%5D+PI9+-+Iteration+2)
+
+### FOSS
+
+- Information about the new [Developer Hub](https://eclipse-tractusx.github.io/docs/developer) section for Eclipse Tractus-X web page
+- Open discussions on the [Mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) or even in the [Matrix Chat](https://chat.eclipse.org/#/room/#tools.tractus-x:matrix.eclipse.org)
+- Reminder for everyone to make small contributions and pull-requests for the next release because security-team , system-team, ip-eclipse-team has limited resources in August
+- Please use the [shared UI components](https://www.npmjs.com/package/cx-portal-shared-components) from the product portal-team for End-User content or follow our [TRG 7.06](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-06)
+- There are some open IP issues open [Eclipse Helpdesk](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/?search=Project%3A%20automotive.tractusx&sort=created_date&state=opened&first_page_size=100)
+- Reminder of sharing your journey on the [EclipseCon](https://www.eclipsecon.org/2023)
+
+## Open discussions
+
+- Input from Portal Team regarding their [working model](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/Dev-flow_deploy-dev-env.md) (working completely on Tractus-X) thanks to [Evelyn](https://github.com/evegufy)
+- Workflow problem showed and discussed with [Aditya](https://github.com/adkumar1)
+
+## Session recording
+
+You can find the
+recording [here](https://bcgcatenax.sharepoint.com/sites/CommunitiesofPractises/_layouts/15/stream.aspx?id=%2Fsites%2FCommunitiesofPractises%2FShared%20Documents%2FCX%2DCoP%20DevSecOps%2FOffice%5FHours%5FRegular%5FRecordings%2FCXDevSecOps%20Office%20Hours%2D20230616%5F114702%2DMeeting%20Recording%2Emp4&referrer=Teams%2ETEAMS%2DELECTRON&referrerScenario=teamsSdk%2DopenFilePreview).


### PR DESCRIPTION
### Description of this Pull Request
#### What would be changed or will be added with this PR?
- add new blog post from last Office Hour on 16.06.2023
#### Why do i want to change this?
- update community
#### Testing
- checkout this branch
- `npm install` (optional)
- `npm start` 
- verify new newsblog entry
#### Visualisation
should look like this:
![image](https://github.com/catenax-ng/catenax-ng.github.io/assets/121097161/dd3a1598-f7ec-42ae-8b38-6cc4ec51233d)

[FaGru3n](https://github.com/FaGru3n), Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) </sub>