### PR TITLE
chore: add office hour blog post from 14072023

### DIFF
--- a/blog/2022-09-23-OfficeHours.md
+++ b/blog/2022-09-23-OfficeHours.md
@@ -15,9 +15,9 @@ __Security:__
 
 - first products onboarded and started scans with invicti
   - SSL/TLS findings - false posivites, will be fixed
-  - JIRA integration is active, onboarding requests via christian.winnen@mhp.com
+  - JIRA integration is active, onboarding requests via [christian.winnen@mhp.com](mailto:christian.winnen@mhp.com)
 - external company has been requested for pen tests
-  contact for requests : dl_CoP_IT_Security@catena-x.net
+  contact for requests : [dl_CoP_IT_Security@catena-x.net](mailto:dl_CoP_IT_Security@catena-x.net)
 
 __FOSS:__
 

--- a/blog/2022-09-30-OfficeHours.md
+++ b/blog/2022-09-30-OfficeHours.md
@@ -9,7 +9,7 @@ tags: [news, officehour]
 
 __DevSecOps:__
 
-- Central Mailbox for contacing System Team: devsecops@catena-x.net
+- Central Mailbox for contacing System Team: [devsecops@catena-x.net](mailto:devsecops@catena-x.net)
 - Please have a look at our new [Tractus-X Release Guidelines](https://catenax-ng.github.io/docs/trg/trg-0) (TRGs)
 
 __Security:__

--- a/blog/2023-03-24-OfficeHours.md
+++ b/blog/2023-03-24-OfficeHours.md
@@ -35,7 +35,7 @@ tags: [news, officehour]
 - Issues with multiple Eclipse Foundation accounts:
   - If you have multiple accounts by accident (i.e. private + company mail), please delete the one you are not using.
     Usually the private one, since you need the company address in your commits for copyright reasons
-  - Deletion request can be sent to 'privacy@eclipse.org'. Best from the Email address you want the account to be deleted
+  - Deletion request can be sent to [privacy@eclipse.org](mailto:devsecops@catena-x.net). Best from the Email address you want the account to be deleted
 - New products directly starting in eclipse-tractusx
   - If you have no code published yet, you can directly start contributing
   - If you already have initial code, you are allowed to push directly, but have to immediately open the initial contribution IP issue afterwards

--- a/blog/2023-05-19-OfficeHours.md
+++ b/blog/2023-05-19-OfficeHours.md
@@ -29,7 +29,7 @@ tags: [news, officehour]
 
 ## Open discussions
 
-- For urgent topics use the [DevSecOps teams CoP channel](https://teams.microsoft.com/l/channel/19%3a9a3c4a05a3514d07b973c13e7b468709%40thread.tacv2/CX%2520-%2520CoP%2520DevSecOps?groupId=17b1a2dc-67fb-4a49-a2ed-dd1344321439&tenantId=1ad22c6d-2f08-4f05-a0ba-e17f6ce88380), the [Eclipse chat](https://chat.eclipse.org/#/room/#tools.tractus-x:matrix.eclipse.org), send a main to the mailing list (tractusx-dev@eclipse.org) or open an [issue in GitHub](https://github.com/eclipse-tractusx/sig-infra/issues/new/choose) so all team members receive the request immediately
+- For urgent topics use the [DevSecOps teams CoP channel](https://teams.microsoft.com/l/channel/19%3a9a3c4a05a3514d07b973c13e7b468709%40thread.tacv2/CX%2520-%2520CoP%2520DevSecOps?groupId=17b1a2dc-67fb-4a49-a2ed-dd1344321439&tenantId=1ad22c6d-2f08-4f05-a0ba-e17f6ce88380), the [Eclipse chat](https://chat.eclipse.org/#/room/#tools.tractus-x:matrix.eclipse.org), send a main to the mailing list [tractusx-dev@eclipse.org](mailto:tractusx-dev@eclipse.org) or open an [issue in GitHub](https://github.com/eclipse-tractusx/sig-infra/issues/new/choose) so all team members receive the request immediately
 - Feel free to open PRs for new organization wide issue templates [here](https://github.com/eclipse-tractusx/.github)
 
 ## Session recording

--- a/blog/2023-07-14-OfficeHours.md
+++ b/blog/2023-07-14-OfficeHours.md
@@ -10,8 +10,10 @@ tags: [ news, officehour ]
 ### DevSecOps
 
 - Keep in mind, that resources at Eclipse Foundation (IP-Team), System-Team and Security-Team will have only limited resources available during holiday season (August 2023).
-- Reminder to set [proper](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-04/) CPU limits on the clusters (especially Beta, Dev). See the [CPU Quota Panel](https://grafana.dev.demo.catena-x.net/d/efa86fd1d0c121a26444b636a3f509a8/kubernetes-compute-resources-cluster?orgId=1&refresh=10s&from=now-7d&to=now&viewPanel=8) which is part of this general [dashboard](https://grafana.dev.demo.catena-x.net/d/efa86fd1d0c121a26444b636a3f509a8/kubernetes-compute-resources-cluster?orgId=1&refresh=10s&from=now-7d&to=now) as reference
+- Gentle reminder to set [proper lower](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-04/) CPU pod ressource requests / limits on dev cluster (no improvements since the last office hour) and same problems occurs on Beta cluster now as well.
+  - See the [CPU Quota Panel](https://grafana.dev.demo.catena-x.net/d/efa86fd1d0c121a26444b636a3f509a8/kubernetes-compute-resources-cluster?orgId=1&refresh=10s&from=now-7d&to=now&viewPanel=8) which is part of this general [dashboard](https://grafana.dev.demo.catena-x.net/d/efa86fd1d0c121a26444b636a3f509a8/kubernetes-compute-resources-cluster?orgId=1&refresh=10s&from=now-7d&to=now) as reference
   unit for CPU fragments are the so called millicores, which means 1000m = 1 full CPU
+  - Hint: [K8s documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits)
 
 ### Security
 

--- a/blog/2023-07-14-OfficeHours.md
+++ b/blog/2023-07-14-OfficeHours.md
@@ -45,4 +45,4 @@ jobs:
 ## Session recording
 
 You can find the
-recording [here](tbd).
+recording [here](https://bcgcatenax.sharepoint.com/sites/CommunitiesofPractises/Shared%20Documents/Forms/AllItems.aspx?OR=Teams%2DHL&CT=1689595535113&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiIxNDE1LzIzMDYwNDAxMTc3IiwiSGFzRmVkZXJhdGVkVXNlciI6ZmFsc2V9&sortField=Modified&isAscending=false&id=%2Fsites%2FCommunitiesofPractises%2FShared%20Documents%2FCX%2DCoP%20DevSecOps%2FOffice%5FHours%5FRegular%5FRecordings%2FMicrosoftTeams%2Dvideo%20%286%29%2Emp4&viewid=a90239a2%2D4eb1%2D446e%2D9246%2Daedc18ebdc75&parent=%2Fsites%2FCommunitiesofPractises%2FShared%20Documents%2FCX%2DCoP%20DevSecOps%2FOffice%5FHours%5FRegular%5FRecordings).

--- a/blog/2023-07-14-OfficeHours.md
+++ b/blog/2023-07-14-OfficeHours.md
@@ -1,0 +1,48 @@
+---
+slug: Office Hours 2023-07-14
+title: Office Hours 2023-07-14
+authors: DevSecOps
+tags: [ news, officehour ]
+---
+
+## General updates / information
+
+### DevSecOps
+
+- Keep in mind, that resources at Eclipse Foundation (IP-Team), System-Team and Security-Team will have only limited resources available during holiday season (August 2023).
+- Reminder to set [proper](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-04/) CPU limits on the clusters (especially Beta, Dev). See the [CPU Quota Panel](https://grafana.dev.demo.catena-x.net/d/efa86fd1d0c121a26444b636a3f509a8/kubernetes-compute-resources-cluster?orgId=1&refresh=10s&from=now-7d&to=now&viewPanel=8) which is part of this general [dashboard](https://grafana.dev.demo.catena-x.net/d/efa86fd1d0c121a26444b636a3f509a8/kubernetes-compute-resources-cluster?orgId=1&refresh=10s&from=now-7d&to=now) as reference
+  unit for CPU fragments are the so called millicores, which means 1000m = 1 full CPU
+
+### Security
+
+- Friendly Reminder: Please look at VeraCode
+- Info to VeraCode Demo session is coming soon
+- Security assessments ongoing
+
+### FOSS
+
+- Presentation from [Paul](https://github.com/paullatzelsperger) "How to use a reusable [Workflow](https://github.com/eclipse-edc/.github/blob/main/.github/workflows/dependency-check.yml) for gradle Dash Licence Check"
+
+```yaml
+jobs:
+ check:
+  uses: eclipse-edc/.github/.github/workflows/dependency-check.yml@main
+```
+
+- Reminder from [Evelyn](https://github.com/evegufy)  "How to use a reusable [Workflow](https://github.com/eclipse-tractusx/sig-infra/blob/main/.github/workflows/reusable-dependencies-dotnet.yaml) for dotnet / yarn Dash Licence Check"
+
+### Test-Managment
+
+- Info from Test Management Feature Freeze on INT Environment 24.07.23 - 16.8.23
+  - Contact: Rainer Herger, Peter Volk, Bernd Rothbrust
+
+## Open discussions
+
+- Feedback and Live Demo to VeraCode [issue](https://github.com/eclipse-tractusx/sig-infra/issues/165)
+- Contact person for ArgoCD / INT Environment shared to the [CoP DevSecOps MS Teams channel](https://teams.microsoft.com/l/channel/19%3a9a3c4a05a3514d07b973c13e7b468709%40thread.tacv2/CX%2520-%2520CoP%2520DevSecOps?groupId=17b1a2dc-67fb-4a49-a2ed-dd1344321439&tenantId=1ad22c6d-2f08-4f05-a0ba-e17f6ce88380)
+- Feedback to [TRG 5.09](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-09/) about Helm Testing
+
+## Session recording
+
+You can find the
+recording [here](tbd).

--- a/blog/2023-07-14-OfficeHours.md
+++ b/blog/2023-07-14-OfficeHours.md
@@ -16,8 +16,9 @@ tags: [ news, officehour ]
 ### Security
 
 - Friendly Reminder: Please look at VeraCode
-- Info to VeraCode Demo session is coming soon
 - Security assessments ongoing
+
+> **Announcement** VeraCode presentation session is planned for the Friday 21.7.2023
 
 ### FOSS
 

--- a/docs/security/contact.md
+++ b/docs/security/contact.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 
 Let's secure Catena-X!
 
-If you have any questions, please contact us *dl_CoP_IT_Security@catena-x.net*
+If you have any questions, please contact us *[dl_CoP_IT_Security@catena-x.net](mailto:dl_CoP_IT_Security@catena-x.net)*
 
 ## Overview
 

--- a/docs/security/how-to-integrate-veracode-to-your-jira-project.md
+++ b/docs/security/how-to-integrate-veracode-to-your-jira-project.md
@@ -25,7 +25,7 @@ the plugin you must meet the following requirements:
 
 ### Steps
 
-1. Contact **dl_CoP_IT_Security@catena-x.net** to request the activation of the automatic
+1. Contact **[dl_CoP_IT_Security@catena-x.net](mailto:dl_CoP_IT_Security@catena-x.net)** to request the activation of the automatic
    imports of the Veracode findings into your Jira project.
 2. Please provide the **Project Name** in Jira and **optionally a Team member** for the issues assignment. This
    team member will be automatically assigned to all imported findings.


### PR DESCRIPTION
### Description of this Pull Request
#### What would be changed or will be added with this PR?
- add new blog post entry from last friday
- modified the email addresses in all suggested files form markdown linting "no-bare-urls" allowed
e.g `no.reply@gihub.com`  changed to `[no.reply@gihub.com](mailto:no.reply@gihub.com)` 
- add announcement for VeraCode presentation

updates https://github.com/eclipse-tractusx/sig-infra/issues/172

@Essenbreis @the-tatanka FYI and your additions to the last office hour

#### Testing
- checkout repo and pr-branch 
- npm install  (optional)
- npm start
- verify changes on the pages (mailadresses) espacially for new blog post
#### Visual preview
![image](https://github.com/catenax-ng/catenax-ng.github.io/assets/121097161/0e29f57e-5a77-4a83-a651-26ca0bce9426)




[FaGru3n](https://github.com/FaGru3n), Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) </sub>