### PR TITLE
chore: rename recording file and fixed link to recording

### DIFF
--- a/blog/2023-07-14-OfficeHours.md
+++ b/blog/2023-07-14-OfficeHours.md
@@ -48,4 +48,4 @@ jobs:
 ## Session recording
 
 You can find the
-recording [here](https://bcgcatenax.sharepoint.com/sites/CommunitiesofPractises/Shared%20Documents/Forms/AllItems.aspx?OR=Teams%2DHL&CT=1689595535113&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiIxNDE1LzIzMDYwNDAxMTc3IiwiSGFzRmVkZXJhdGVkVXNlciI6ZmFsc2V9&sortField=Modified&isAscending=false&id=%2Fsites%2FCommunitiesofPractises%2FShared%20Documents%2FCX%2DCoP%20DevSecOps%2FOffice%5FHours%5FRegular%5FRecordings%2FMicrosoftTeams%2Dvideo%20%286%29%2Emp4&viewid=a90239a2%2D4eb1%2D446e%2D9246%2Daedc18ebdc75&parent=%2Fsites%2FCommunitiesofPractises%2FShared%20Documents%2FCX%2DCoP%20DevSecOps%2FOffice%5FHours%5FRegular%5FRecordings).
+recording [here](https://bcgcatenax.sharepoint.com/:v:/r/sites/CommunitiesofPractises/Shared%20Documents/CX-CoP%20DevSecOps/Office_Hours_Regular_Recordings/20230714_DevSecOps%20Business%20Hours-Recording.mp4?csf=1&web=1&e=yuBcCw).

--- a/blog/2023-08-25-OfficeHours.md
+++ b/blog/2023-08-25-OfficeHours.md
@@ -51,4 +51,4 @@ During the QG Checks a couple of things popped up:
 ## Session recording
 
 - You can find the
-  recording [here](https://bcgcatenax.sharepoint.com/:v:/r/sites/CommunitiesofPractises/Shared%20Documents/CX-CoP%20DevSecOps/Office_Hours_Regular_Recordings/20230824_DevSecOps-Office-Hour.mp4?csf=1&web=1&e=eFWQxO).
+  recording [here](https://bcgcatenax.sharepoint.com/:v:/r/sites/CommunitiesofPractises/Shared%20Documents/CX-CoP%20DevSecOps/Office_Hours_Regular_Recordings/20230825_DevSecOps-Business%20Hours-Recording.mp4?csf=1&web=1&e=rr9V3Z).


### PR DESCRIPTION
renamed files for the recordings and now adapt to this link within our news blog