### PR TITLE
fix: link to getting started overview page

### DIFF
--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -18,7 +18,7 @@ const FeatureList = [
     Svg: require('@site/static/img/rocket-svgrepo-com.svg').default,
     description: (
       <>
-          We ask you to make yourself familiar with our Documentation first by starting with our <a href="/docs/getstarted/intro">Getting Started</a> document.
+          We ask you to make yourself familiar with our Documentation first by starting with our <a href="/docs/getstarted/overview">Getting Started</a> document.
       </>
     ),
   },


### PR DESCRIPTION
#### What would be changed or will be added with this PR?
- missed a link to update to our overview page
#### Why do i want to change this?
- current link on https://catenax-ng.github.io/ does not work page not found
#### Testing
- checkout branch
- npm install 
- npm start
- verify link to /docs/overview

