### PR TITLE
docs: add link to current meetings overview

### DIFF
--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -8,7 +8,7 @@ const FeatureList = [
     Svg: require('@site/static/img/support-svgrepo-com.svg').default,
     description: (
       <>
-          We have an 1h Office <a href="https://confluence.catena-x.net/pages/viewpage.action?pageId=25228715#InternalCatenaXinformationforsharingthroughLanding/Supportpage-OfficeHourCalendarInvite">Hour every Friday</a>. Feel free to join and ask your questions directly there.<br/><br/>
+          We have an 1h <a href="https://eclipse-tractusx.github.io/community/open-meetings">Office Hour</a> Meeting every Friday. Feel free to join and ask your questions directly there.<br/><br/>
           You can also join us on Catena-X <b>MS Teams</b> channel <b><a target="_blank" href="https://teams.microsoft.com/l/channel/19%3a9a3c4a05a3514d07b973c13e7b468709%40thread.tacv2/CX%2520-%2520CoP%2520DevSecOps?groupId=17b1a2dc-67fb-4a49-a2ed-dd1344321439&tenantId=1ad22c6d-2f08-4f05-a0ba-e17f6ce88380">Communities of Practices -> CX - CoP DevSecOps</a></b>.
       </>
     ),


### PR DESCRIPTION
#### What would be changed or will be added with this PR?
- update link to the Office Hour invitation to current approach to get the ics files

#### Why do i want to change this?
- https://github.com/eclipse-tractusx/sig-infra/issues/348

#### Testing
- checkout repo
- npm install (optional)
- npm start
- verify link
